### PR TITLE
use syncupdate API, and depend on LWP::UserAgent instead of WWW::Mechanize

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Revision history for net-whois-ripe
 
+            - Depend on LWP::UserAgent instead of WWW::Mechanize
             
 2.00015     17 Jul 2012
             - Change the way to test if t/common.pl was well loaded

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ WriteMakefile(
     },
     META_MERGE => {
         recommends => {
-                    'WWW::Mechanize' => 0,
+                    'LWP::UserAgent' => 0,
         },
         resources => { 
                         repository => 'https://github.com/arhuman/Net-Whois-RIPE',

--- a/t/215-SyncUpdates.t
+++ b/t/215-SyncUpdates.t
@@ -6,11 +6,11 @@ use Net::Whois::RIPE;
 use Net::Whois::Object;
 use Data::Dumper;
 
-our $MECHANIZED;
+our $LWP;
 BEGIN {
-    $MECHANIZED = do {
+    $LWP = do {
         eval {
-            require WWW::Mechanize;
+            require LWP::UserAgent;
         };
         ($@) ? 0 : 1;
     };
@@ -21,8 +21,8 @@ unless ( $ENV{TEST_MNTNER} && $ENV{TEST_MNTNER_PASSWORD} ) {
     plan skip_all => ' Set environment vars for server testing';
 }
 
-unless ($MECHANIZED) {
-    plan skip_all => 'WWW::Mechanize installation required for update';
+unless ($LWP) {
+    plan skip_all => 'LWP::UserAgent installation required for update';
 }
 
 plan tests => 5;


### PR DESCRIPTION
This should be robuster (HTTP status code directly indicates success or
failure), and since WWW::Mechanize depends on LWP::UserAgent, it also
slightly reduces the prerequisites
