### PR TITLE
fix regex in syncupdates_create

### DIFF
--- a/lib/Net/Whois/Object.pm
+++ b/lib/Net/Whois/Object.pm
@@ -427,7 +427,7 @@ sub syncupdates_create {
 
     my $html = $self->_syncupdates_submit( $self->dump(), $password );
 
-    if ( $html =~ /\*\*\*Info:\s+Authorisation for\s+\[.+\]\s+(\S+)\s*$/m ) {
+    if ( $html =~ /\*\*\*Info:\s+Authorisation for\[[^\]]+]\s+(.+)\s*$/m ) {
         my $value = $1;
         $self->_single_attribute_setget( $key, $value );
         return $value;


### PR DESCRIPTION
when creating an inetnum, the response can have whitespaces in the
primary key, for example
***Info: Authorisation for  [inetnum] 62.128.31.140 - 62.128.31.143
