### PR TITLE
reduce memory load by storing meta information per class

### DIFF
--- a/lib/Net/Whois/Object.pm
+++ b/lib/Net/Whois/Object.pm
@@ -273,10 +273,10 @@ sub attributes {
     croak "Invalid attribute's type ($type)" unless $type =~ m/(all|primary|mandatory|optional|single|multiple)/i;
     if ($ra_attributes) {
         for my $a ( @{$ra_attributes} ) {
-            $self->{TYPE}{$type}{$a} = 1;
+            $self->_TYPE()->{$type}{$a} = 1;
         }
     }
-    return sort keys %{ $self->{TYPE}{$type} };
+    return sort keys %{ $self->_TYPE()->{$type} };
 }
 
 =head2 B<class ( )>
@@ -300,7 +300,7 @@ This method return true if $attribute is of type $type.
 sub attribute_is {
     my ( $self, $attribute, $type ) = @_;
 
-    return defined $self->{TYPE}{$type}{$attribute} ? 1 : 0;
+    return defined $self->_TYPE()->{$type}{$attribute} ? 1 : 0;
 
     # for my $att ( $self->attributes( $type )) {
     #     if ($att eq $attribute) { return 1; }
@@ -628,8 +628,6 @@ sub _syncupdates_submit {
 Sign the C<$text> with the C<gpg> command and gpg information in C<$auth>
 Returns the signed text.
 
-=end UNDOCUMENTED
-
 =cut
 
 sub _pgp_sign {
@@ -656,6 +654,21 @@ sub _pgp_sign {
     return $text;
 }
 
+=head2 B<_TYPE>
+
+Returns a hash ref that contains the attribute data for the class
+of the object that the method was called on.
+
+=end UNDOCUMENTED
+
+=cut
+
+my %TYPES;
+sub _TYPE {
+    $TYPES{ref $_[0]} ||= {}
+}
+
+
 
 =head1 TODO
 
@@ -674,7 +687,7 @@ Thanks to Luis Motta Campos for his trust when allowing me to publish this
 release.
 
 Thanks to Moritz Lenz for all his contributions
-(Thanks also to 'Noris Network AG', his employer for allowing him to contribute in the office hours)
+(Thanks also to 'Noris Network AG', his employer, for allowing him to contribute in the office hours)
 
 =cut
 


### PR DESCRIPTION
previously each object would carry per-class information around with it,
now it is only stored once per class
