### PR TITLE
drop dependency on Iterator::Util

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,6 @@ WriteMakefile(
     PREREQ_PM        => {
                    'Test::More'     => 0,
                    'Iterator'       => 0,
-                   'Iterator::Util' => 0,
     },
     META_MERGE => {
         recommends => {

--- a/lib/Net/Whois/RIPE.pm
+++ b/lib/Net/Whois/RIPE.pm
@@ -6,7 +6,6 @@ use strict;
 use IO::Socket::INET;
 use IO::Select;
 use Iterator;
-use Iterator::Util;
 
 use constant {
     SOON                    => 30,
@@ -515,9 +514,12 @@ connection will be terminated after this query.
 
 sub object_types {
     my $self = shift;
-    my $iterator = igrep { !m{^%\s} } $self->__query(QUERY_LIST_OBJECTS);
-    return if $iterator->is_exhausted;
-    return split qr{\s+}, $iterator->value;
+    my $iterator = $self->__query(QUERY_LIST_OBJECTS);
+    while (!$iterator->is_exhausted) {
+        my $value = $iterator->value;
+        return split /\s+/, $value if $value !~ /^%\s/;
+    }
+    return;
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
While usually I am all in favor of code reuse, I also have to package
dependencies for Debian Lenny (urh), here it takes only three extra
extra lines of code to drop the dependency.

(I understand that if you plan to expand the usage of iterators, you'll likely reject that patch. That's fine).
