### PR TITLE
add 'align' method

### DIFF
--- a/lib/Net/Whois/Object.pm
+++ b/lib/Net/Whois/Object.pm
@@ -6,6 +6,7 @@ use Carp;
 use Net::Whois::RIPE;
 use Data::Dumper;
 use IPC::Open2 qw/open2/;
+use List::Util qw/max/;
 
 our $LWP;
 BEGIN {
@@ -373,6 +374,44 @@ sub dump {
 
     return $result;
 }
+
+=head2 B<align( $column )>
+
+Changes the object by adding or removing leading whitespace,
+so that all C<< $self->dump >> produces values that are aligned
+vertically on column C<$column>.
+
+If C<$column> is omitted, it is chosen large enough to make vertical
+alignment possible for all values.
+
+=cut
+
+sub align {
+    my $self     = shift;
+    my $align_to = shift;
+
+    # $self->dump adds one colon and five spaces,
+    # so there's a padding of 5
+    my $padding = 5;
+    $align_to  ||= $padding + max map length, $self->attributes('all');
+
+    for ($self->attributes('single')) {
+        my $alignment = ' ' x ($align_to - $padding - length);
+        if (exists $self->{$_}) {
+            $self->{$_} =~ s/^\s*/$alignment/;
+        }
+    }
+
+    for ($self->attributes('multiple')) {
+        my $alignment = ' ' x ($align_to - $padding - length);
+        if (exists $self->{$_}) {
+            s/^\s*/$alignment/ for @{ $self->{$_} };
+        }
+    }
+
+    return $self;
+}
+
 
 =head2 B<syncupdates_update( $password )>
 

--- a/t/105-AsBlock.t
+++ b/t/105-AsBlock.t
@@ -92,10 +92,37 @@ is( $object->source(), 'RIPE # Filtered', 'source properly parsed' );
 $object->source('APNIC');
 is( $object->source(), 'APNIC', 'source properly set' );
 
+# test 'align'
+my $align = Net::Whois::Object::AsBlock->new(
+    as_block  =>   'AS30720 - AS30895',
+    descr     =>   'RIPE NCC ASN block',
+    remarks   =>   'These AS Numbers are further assigned to network',
+    remarks   =>   'operators in the RIPE NCC service region. AS',
+    remarks   =>   'assignment policy is documented in:',
+    remarks   =>   '<http://www.ripe.net/ripe/docs/asn-assignment.html>',
+    remarks   =>   'RIPE NCC members can request AS Numbers using the',
+    remarks   =>   'form available in the LIR Portal or at:',
+    remarks   =>   '<http://www.ripe.net/ripe/docs/asnrequestform.html>',
+    org       =>   'ORG-NCC1-RIPE',
+    admin_c   =>   'CREW-RIPE',
+    tech_c    =>   'RD132-RIPE',
+    mnt_by    =>   'RIPE-DBM-MNT',
+    notify    =>   'RIPE-DBM-MNT',
+    mnt_lower =>   'RIPE-NCC-HM-MNT',
+    changed   =>   'arhuman@gmail.com 20120701',
+    source    =>   'RIPE # Filtered',
+);
+$align->align(30);
+
+for (split /\n/, $align->dump) {
+    ok $_ =~ /^.{29}\s\S/, "Line '$_' is aligned to column 30";
+}
+
 # Common tests
 do 't/common.pl';
 ok( $tested{common_loaded}, "t/common.pl properly loaded" );
 ok( !$@, "Can evaluate t/common.pl ($@)" );
+
 
 __DATA__
 as-block:       AS30720 - AS30895


### PR DESCRIPTION
When a Net::Whois::Object::\* object is created in the style
Net::Whois::Object::InetNum->new(
    inetnum => $inetnum,
    org     => $org,
    ...
);
the ->dump output is not aligned by default, which means
that unaligned data is entered into the RIPE db, which people
generally don't find very pretty.

This patches adds an ->align method which pads the values with
whitespace to generate nice visual layout.
