### PR TITLE
fix intermittent error in global destruction

### DIFF
--- a/lib/Net/Whois/RIPE.pm
+++ b/lib/Net/Whois/RIPE.pm
@@ -437,7 +437,8 @@ sub disconnect {
     if ( $self->is_connected ) {
         my $socket = $self->{__state}{socket};
         $socket->close;
-        $self->{__state}{ioselect}->remove($socket);
+        $self->{__state}{ioselect}->remove($socket)
+            if $self->{__state}{ioselect};
         delete $self->{__state}{socket};
     }
 }


### PR DESCRIPTION
In a largish application using Net::Whois::RIPE, I sometimes get

```
    (in cleanup) Can't call method "remove" on an undefined value at /usr/share/perl5/Net/Whois/RIPE.pm line 440 during global destruction.
```

I don't know what exact circumstances lead to it, but IMHO it's not worth dying for :-)

(fixed version of an earlier pull request that included quite some garbage)
