### PR TITLE
Object type "Organisation" needs a field abuse-c

### DIFF
--- a/lib/Net/Whois/Object/Organisation.pm
+++ b/lib/Net/Whois/Object/Organisation.pm
@@ -21,6 +21,7 @@ use base qw/Net::Whois::Object/;
 # geoloc:         [optional]   [single]     [ ]
 # language:       [optional]   [multiple]   [ ]
 # org:            [optional]   [multiple]   [inverse key]
+# abuse-c:        [optional]   [multiple]   [inverse key]
 # admin-c:        [optional]   [multiple]   [inverse key]
 # tech-c:         [optional]   [multiple]   [inverse key]
 # ref-nfy:        [optional]   [multiple]   [inverse key]
@@ -33,9 +34,9 @@ use base qw/Net::Whois::Object/;
 
 __PACKAGE__->attributes( 'primary',   ['organisation'] );
 __PACKAGE__->attributes( 'mandatory', [ 'organisation', 'org_name', 'org_type', 'address', 'e_mail', 'mnt_ref', 'mnt_by', 'changed', 'source' ] );
-__PACKAGE__->attributes( 'optional',  [ 'descr', 'remarks', 'phone', 'fax_no', 'geoloc', 'language', 'org', 'admin_c', 'tech_c', 'ref_nfy', 'notify', 'abuse_mailbox' ] );
+__PACKAGE__->attributes( 'optional',  [ 'descr', 'remarks', 'phone', 'fax_no', 'geoloc', 'language', 'org', 'abuse_c', 'admin_c', 'tech_c', 'ref_nfy', 'notify', 'abuse_mailbox' ] );
 __PACKAGE__->attributes( 'single', [ 'organisation', 'org_name', 'org_type', 'geoloc','source' ] );
-__PACKAGE__->attributes( 'multiple', [ 'descr', 'remarks', 'address', 'phone', 'fax_no', 'e_mail','language', 'org', 'admin_c', 'tech_c', 'ref_nfy', 'mnt_ref', 'notify','abuse_mailbox', 'mnt_by', 'changed' ] );
+__PACKAGE__->attributes( 'multiple', [ 'descr', 'remarks', 'address', 'phone', 'fax_no', 'e_mail','language', 'org', 'abuse_c', 'admin_c', 'tech_c', 'ref_nfy', 'mnt_ref', 'notify','abuse_mailbox', 'mnt_by', 'changed' ] );
 
 =head1 NAME
 

--- a/t/190-Organisation.t
+++ b/t/190-Organisation.t
@@ -20,7 +20,7 @@ isa_ok $object, $class;
 
 # Non-inherited methods
 can_ok $object, qw( organisation org_name org_type descr remarks address phone
-    e_mail fax_no org admin_c tech_c ref_nfy mnt_ref notify mnt_by changed source);
+    e_mail fax_no org abuse_c admin_c tech_c ref_nfy mnt_ref notify mnt_by changed source);
 
 # Check if typed attributes are correct
 can_ok $object, $object->attributes('mandatory');
@@ -85,6 +85,11 @@ $tested{'language'}++;
 is_deeply( $object->language(), ['FR','EN'], 'language properly parsed' );
 $object->language('ES');
 is( $object->language()->[2], 'ES', 'language properly added' );
+
+# Test 'abuse_c'
+$tested{'abuse_c'}++;
+$object->abuse_c('CPNY-ADM2');
+is( $object->abuse_c()->[0], 'CPNY-ADM2', 'abuse_c properly added' );
 
 # Test 'admin_c'
 $tested{'admin_c'}++;


### PR DESCRIPTION
There is a schema change in progress that adds this attribute, see
http://www.ripe.net/ripe/mail/archives/anti-abuse-wg/2012-November/001974.html
If you do a 'whois -h whois.ripe.net ORG-nnA1-RIPE' you'll see that it already
returns an 'abuse-c' field, which makes Net::Whois::Object->new die without  this patch.
